### PR TITLE
Convert <%== to <%= to prevent syntax error, unexpected '='

### DIFF
--- a/lib/redis_dashboard/views/index.erb
+++ b/lib/redis_dashboard/views/index.erb
@@ -20,7 +20,7 @@
         </div>
         <div>
           <span class="label">Cache hit ratio</span>
-          <span><%== format_impact_percentage compute_cache_hit_ratio(info) %></span>
+          <span><%= format_impact_percentage compute_cache_hit_ratio(info) %></span>
         </div>
       </div>
     </div>

--- a/lib/redis_dashboard/views/layout.erb
+++ b/lib/redis_dashboard/views/layout.erb
@@ -24,7 +24,7 @@
           </div>
         <% end %>
       </div>
-      <%== yield %>
+      <%= yield %>
       <div class="page-footer">
         Made by <a href="https://basesecrete.com/en/">Base Secrète</a>.  MIT License. <a href="https://github.com/BaseSecrete/redis_dashboard">Fork on GitHub</a>.
         <div class="rorvswild">

--- a/lib/redis_dashboard/views/slowlog.erb
+++ b/lib/redis_dashboard/views/slowlog.erb
@@ -1,5 +1,5 @@
 <p>
-  List up to <%= client.config["slowlog-max-len"] %> commands slower than <%== format_usec client.config["slowlog-log-slower-than"] %>.
+  List up to <%= client.config["slowlog-max-len"] %> commands slower than <%= format_usec client.config["slowlog-log-slower-than"] %>.
   It is defined in your config by <em>slowlog-max-len</em> and <em>slowlog-log-slower-than</em>.
 </p>
 
@@ -16,7 +16,7 @@
       <tr>
         <td><%= cmd.id %></td>
         <td class="date"><%= epoch_to_short_date_time cmd.timestamp %></td>
-        <td class="number"><%== format_usec cmd.microseconds %></td>
+        <td class="number"><%= format_usec cmd.microseconds %></td>
         <td><%= cmd.command.join(" ") %></td>
       </tr>
     <% end %>

--- a/lib/redis_dashboard/views/stats.erb
+++ b/lib/redis_dashboard/views/stats.erb
@@ -10,10 +10,10 @@
     <% for (key,hash) in stats %>
       <tr>
         <td class="key"><%= key %></td>
-        <td class="number"><%== format_usec hash["usec"] %></td>
+        <td class="number"><%= format_usec hash["usec"] %></td>
         <td class="number"><%= hash["calls"] %></td>
-        <td class="number"><%== format_usec hash["usec_per_call"] %></td>
-        <td class="number"><%== format_impact_percentage hash["impact"] %></td>
+        <td class="number"><%= format_usec hash["usec_per_call"] %></td>
+        <td class="number"><%= format_impact_percentage hash["impact"] %></td>
       </tr>
     <% end %>
   </table>


### PR DESCRIPTION
I don't know the <%== syntax in ruby, but I get syntax errors when running this code in rails 6.

```
2019-10-08 23:17:30 - SyntaxError - /Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/redis_dashboard-0.1.6/lib/redis_dashboard/views/index.erb:23: syntax error, unexpected '='
...<span>".freeze; @_out_buf.<<((= format_impact_percentage com...
...                              ^:
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:269:in `class_eval'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:269:in `compile_template_method'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:236:in `block in compiled_method'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:235:in `synchronize'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:235:in `compiled_method'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:169:in `evaluate'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/sinatra-2.0.7/lib/sinatra/base.rb:834:in `render'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/sinatra-2.0.7/lib/sinatra/base.rb:682:in `erb'
	/Users/benjaminwols/.rvm/gems/ruby-2.6.3@ans/gems/redis_dashboard-0.1.6/lib/redis_dashboard/application.rb:12:in `block in <class:Application>'
```